### PR TITLE
test: add missing --color argument

### DIFF
--- a/scripts/report-to-gl-codeclimate.py
+++ b/scripts/report-to-gl-codeclimate.py
@@ -77,6 +77,7 @@ def main():
                         default=sys.stdin)
     parser.add_argument("--output-file", type=str)
     parser.add_argument("--tee", action="store_true", default=False)
+    parser.add_argument("--color", choices=["auto", "always", "never"], default="never")
     options = parser.parse_args()
     ignored = 0
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -12,9 +12,10 @@ from flake8_gl_codeclimate import GitlabCodeClimateFormatter
 class TestGitlabCodeClimateFormatter(unittest.TestCase):
 
     def setUp(self):
-        self.options = unittest.mock.Mock(["output_file", "tee"])
+        self.options = unittest.mock.Mock(["output_file", "tee", "color"])
         self.options.output_file = tempfile.mktemp(suffix=".json", dir=".")
         self.options.tee = False
+        self.options.color = 'auto'
 
         self.formatter = GitlabCodeClimateFormatter(self.options)
         self.error1 = Violation(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -57,6 +57,7 @@ class TestGtlabCodeClimate(unittest.TestCase):
         args = [
             "flake8",
             "--output-file", self.flake8_output_fn,
+            "--color", "never",
             "examples/bad.py",
         ]
         subprocess.call(args)
@@ -81,6 +82,7 @@ class TestGtlabCodeClimate(unittest.TestCase):
             "flake8",
             "--format", "pylint",
             "--output-file", self.flake8_output_fn,
+            "--color", "never",
             "examples/bad.py",
         ]
         subprocess.call(args)
@@ -106,6 +108,7 @@ class TestGtlabCodeClimate(unittest.TestCase):
             "flake8",
             "--show-source",
             "--output-file", self.flake8_output_fn,
+            "--color", "never",
             "examples/bad.py",
         ]
         subprocess.call(args)


### PR DESCRIPTION
Adds support for running the tests of this plugin with flake8 v5